### PR TITLE
confirm websocket commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+18.08
+
+- incapsulate websocket logic to separate module
+- 
+
 18.07.02
 
 - MediaInfo include active streams information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 18.08
 
 - incapsulate websocket logic to separate module
-- 
+- onStartStalling, onEndStalling, onSeeked callbacks methods
 
 18.07.02
 

--- a/messages.ru.md
+++ b/messages.ru.md
@@ -1,0 +1,23 @@
+порядок сообщений с сервера после play
+
+открытие соединение с вебсокетом:
+`mse-init-segment`
+нужно послать send('resume')
+`event:resumed`
+`ArrayBuffer`
+...
+`ArrayBuffer`
+
+seek:
+`mb old frames:ArrayBuffer`
+`event:seeked`
+`ArrayBuffer`
+...
+`ArrayBuffer`
+
+seek live:
+`mb old frames:ArrayBuffer`
+`event:switched_to_live`
+`ArrayBuffer`
+...
+`ArrayBuffer`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flussonic/flussonic-mse-player",
-  "version": "18.07.2",
+  "version": "18.08.0",
   "description": "Media Source Extension support for Flussonic.",
   "main": "./dist/FlussonicMsePlayer.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-env": "^1.6.0",
     "clean-webpack-plugin": "^0.1.17",
     "directory-named-webpack-plugin": "^2.2.3",
+    "jest": "^23.5.0",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   },

--- a/src/FlussonicMsePlayer.test.js
+++ b/src/FlussonicMsePlayer.test.js
@@ -1,0 +1,22 @@
+import MSEPlayer from './FlussonicMsePlayer'
+
+const rawUrl = 'http://localhost:8080/clock/mse_ld'
+
+test('1. constructor return MSEPlayer instance', () => {
+  const url = MSEPlayer.replaceHttpByWS(rawUrl)
+  const mse = new MSEPlayer(null, url, {debug: true});
+
+  expect(mse instanceof MSEPlayer).toBe(true);
+  expect(mse.url === url).toBe(true)
+
+
+})
+
+test('2. reject processing play() if this.playing flag is true', () => {
+  const url = MSEPlayer.replaceHttpByWS(rawUrl)
+  const mse = new MSEPlayer(null, url, {debug: true});
+  mse.playing = true
+  mse.play().then((data) => {
+    return expect(data).toEqual({message: '[mse-player] _play: terminate because already has been playing'})
+  })
+})

--- a/src/controllers/buffers.js
+++ b/src/controllers/buffers.js
@@ -1,0 +1,243 @@
+import {
+  doArrayBuffer,
+  base64ToArrayBuffer,
+  RawDataToUint8Array,
+  getTrackId,
+} from '../utils/mseUtils'
+import {logger, enableLogs} from '../utils/logger'
+
+import {AUDIO, VIDEO} from '../enums/common'
+import {BUFFER_UPDATE_END} from '../enums/events'
+// TODO: ? doArrayBuffer > this.utc
+
+export default class BuffersController {
+  constructor(opts = {}) {
+    logger.log('create BuffersController')
+    this.flushRange = []
+    this.appended = 0
+    this.mediaSource = opts.mediaSource
+    this.segments = []
+    this.sourceBuffer = {}
+
+    this.doArrayBuffer = doArrayBuffer.bind(this)
+    this.maybeAppend = this.maybeAppend.bind(this)
+    this.onSBUpdateEnd = this.onSBUpdateEnd.bind(this)
+  }
+
+  setMediaSource(ms) {
+    this.mediaSource = ms
+  }
+
+  createSourceBuffers(data) {
+    const sb = this.sourceBuffer;
+
+    data.tracks.forEach((s) => {
+      const isVideo = s.content === VIDEO;
+      const mimeType = isVideo
+        ? 'video/mp4; codecs="avc1.4d401f"'
+        : 'audio/mp4; codecs="mp4a.40.2"'
+
+      const id = s.id
+
+      sb[s.content] = this.mediaSource.addSourceBuffer(mimeType)
+      const buffer = sb[s.content]
+
+      buffer.addEventListener(BUFFER_UPDATE_END, this.onSBUpdateEnd)
+    })
+
+  }
+
+  onSBUpdateEnd() {
+    if (this._needsFlush) {
+      this.doFlush()
+    }
+    if (!this._needsFlush && this.segments.length) {
+      this.doArrayBuffer()
+    }
+  }
+
+  createTracks(tracks) {
+    tracks.forEach(track => {
+      const view = base64ToArrayBuffer(track.payload)
+      const segment = {
+        type: this.getTypeBytrackId(track.id),
+        isInit: true,
+        data: view,
+      }
+      this.maybeAppend(segment)
+    })
+  }
+
+  maybeAppend(segment) {
+
+    if (this._needsFlush) {
+      this.segments.unshift(segment)
+      return
+    }
+
+    const buffer = this.sourceBuffer[segment.type]
+
+    if (buffer.updating) {
+      this.segments.unshift(segment)
+    } else {
+      buffer.appendBuffer(segment.data)
+      this.appended++
+      // TODO: find where switch off
+      this.appending = true
+    }
+  }
+
+  setTracksByType(data) {
+    data.tracks.forEach((s) => {
+      const isVideo = s.content === VIDEO;
+      const id = s.id
+
+      if (!isVideo) {
+        this.audioTrackId = id
+      } else {
+        this.videoTrackId = id
+      }
+
+    })
+  }
+
+  getTypeBytrackId(id) {
+    return this.audioTrackId === id
+      ? AUDIO
+      : VIDEO
+  }
+
+  procArrayBuffer(rawData) {
+    const segment = this.rawDataToSegmnet(rawData)
+    this.segments.push(segment)
+    this.doArrayBuffer()
+  }
+
+  seek() {
+    for(let k in this.sourceBuffer) {
+      this.sourceBuffer[k].abort()
+      this.sourceBuffer[k].mode = BUFFER_MODE_SEQUENCE
+    }
+
+    this.segments = []
+  }
+
+  isBuffered() {
+    let appended = 0
+    let sourceBuffer = this.sourceBuffer;
+    for (let type in sourceBuffer) {
+      appended += sourceBuffer[type].buffered.length;
+    }
+    return appended > 0
+  }
+
+  doFlush () {
+    // loop through all buffer ranges to flush
+    while (this.flushRange.length) {
+      let range = this.flushRange[0];
+      // flushBuffer will abort any buffer append in progress and flush Audio/Video Buffer
+      if (this.flushBuffer(range.start, range.end, range.type)) {
+        // range flushed, remove from flush array
+        this.flushRange.shift();
+        this.flushBufferCounter = 0;
+      } else {
+        this._needsFlush = true;
+        // avoid looping, wait for SB update end to retrigger a flush
+        return;
+      }
+    }
+    if (this.flushRange.length === 0) {
+      // everything flushed
+      this._needsFlush = false;
+
+      // let's recompute this.appended, which is used to avoid flush looping
+      let appended = 0;
+      let sourceBuffer = this.sourceBuffer;
+      try {
+        for (let type in sourceBuffer) {
+          appended += sourceBuffer[type].buffered.length;
+        }
+      } catch (error) {
+        // error could be thrown while accessing buffered, in case sourcebuffer has already been removed from MediaSource
+        // this is harmess at this stage, catch this to avoid reporting an internal exception
+        logger.error('error while accessing sourceBuffer.buffered');
+      }
+      this.appended = appended;
+      this._setTracksFlag = false
+    }
+  }
+
+  /*
+    flush specified buffered range,
+    return true once range has been flushed.
+    as sourceBuffer.remove() is asynchronous, flushBuffer will be retriggered on sourceBuffer update end
+  */
+  flushBuffer (startOffset, endOffset, typeIn) {
+    let sb, i, bufStart, bufEnd, flushStart, flushEnd, sourceBuffer = this.sourceBuffer;
+    if (Object.keys(sourceBuffer).length) {
+      logger.log(`flushBuffer,pos/start/end: ${this.media.currentTime.toFixed(3)}/${startOffset}/${endOffset}`);
+      // safeguard to avoid infinite looping : don't try to flush more than the nb of appended segments
+      if (this.flushBufferCounter < this.appended) {
+        for (let type in sourceBuffer) {
+          // check if sourcebuffer type is defined (typeIn): if yes, let's only flush this one
+          // if no, let's flush all sourcebuffers
+          if (typeIn && type !== typeIn) {
+            continue;
+          }
+
+          sb = sourceBuffer[type];
+          // we are going to flush buffer, mark source buffer as 'not ended'
+          sb.ended = false;
+          if (!sb.updating) {
+            try {
+              for (i = 0; i < sb.buffered.length; i++) {
+                bufStart = sb.buffered.start(i);
+                bufEnd = sb.buffered.end(i);
+                // workaround firefox not able to properly flush multiple buffered range.
+                if (navigator.userAgent.toLowerCase().indexOf('firefox') !== -1 && endOffset === Number.POSITIVE_INFINITY) {
+                  flushStart = startOffset;
+                  flushEnd = endOffset;
+                } else {
+                  flushStart = Math.max(bufStart, startOffset);
+                  flushEnd = Math.min(bufEnd, endOffset);
+                }
+                /* sometimes sourcebuffer.remove() does not flush
+                   the exact expected time range.
+                   to avoid rounding issues/infinite loop,
+                   only flush buffer range of length greater than 500ms.
+                */
+                if (Math.min(flushEnd, bufEnd) - flushStart > 0.5) {
+                  this.flushBufferCounter++;
+                  logger.log(`flush ${type} [${flushStart},${flushEnd}], of [${bufStart},${bufEnd}], pos:${this.media.currentTime}`);
+                  sb.remove(flushStart, flushEnd);
+                  return false;
+                }
+              }
+            } catch (e) {
+              logger.warn('exception while accessing sourcebuffer, it might have been removed from MediaSource');
+            }
+          } else {
+            // logger.log('abort ' + type + ' append in progress');
+            // this will abort any appending in progress
+            // sb.abort();
+            logger.warn('cannot flush, sb updating in progress');
+            return false;
+          }
+        }
+      } else {
+        logger.warn('abort flushing too many retries');
+      }
+      logger.log('buffer flushed');
+    }
+    // everything flushed !
+    return true;
+  }
+
+  rawDataToSegmnet(rawData) {
+    const view = RawDataToUint8Array(rawData)
+    const trackId = getTrackId(view)
+    const trackType = this.getTypeBytrackId(trackId)
+    return {type: trackType, data: view}
+  }
+
+}

--- a/src/controllers/buffers.js
+++ b/src/controllers/buffers.js
@@ -10,6 +10,9 @@ import {AUDIO, VIDEO} from '../enums/common'
 import {BUFFER_UPDATE_END} from '../enums/events'
 // TODO: ? doArrayBuffer > this.utc
 
+
+const BUFFER_MODE_SEQUENCE = 'sequence' // segments
+
 export default class BuffersController {
   constructor(opts = {}) {
     logger.log('create BuffersController')

--- a/src/controllers/mediaSource.js
+++ b/src/controllers/mediaSource.js
@@ -1,0 +1,121 @@
+import {logger, enableLogs} from '../utils/logger'
+
+export default class MediaSourceController {
+  constructor(opts) {
+
+    logger.log('create BuffersController')
+  }
+
+
+  onAttachMedia(data) {
+    this.media = data.media
+    const media = this.media
+    if (!(media instanceof HTMLMediaElement)) {
+      throw new Error(MSG.NOT_HTML_MEDIA_ELEMENT)
+    }
+    if (media) {
+      // setup the media source
+      const ms = (this.mediaSource = new MediaSource())
+      //Media Source listeners
+
+      this.onmse = this.onMediaSourceEnded.bind(this)
+      this.onmsc = this.onMediaSourceClose.bind(this)
+
+      ms.addEventListener(EVENTS.MEDIA_SOURCE_SOURCE_ENDED, this.onmse)
+      ms.addEventListener(EVENTS.MEDIA_SOURCE_SOURCE_CLOSE, this.onmsc)
+      // link video and media Source
+      media.src = URL.createObjectURL(ms)
+
+      this.oncvp = mseUtils.checkVideoProgress(media, this).bind(this)
+      this.media.addEventListener(EVENTS.MEDIA_ELEMENT_PROGRESS, this.oncvp)
+      return new Promise(resolve => {
+        this.onmso = this.onMediaSourceOpen.bind(this, resolve)
+        ms.addEventListener(EVENTS.MEDIA_SOURCE_SOURCE_OPEN, this.onmso)
+      })
+    }
+  }
+
+    play() {
+      // TODO: to observe this case, I have no idea when it fired
+      if (!this.mediaSource) {
+        this.onAttachMedia({media: this.media})
+        this.onsoa = this._play.bind(this, from, videoTrack, audioTack)
+        this.mediaSource.addEventListener(EVENTS.MEDIA_SOURCE_SOURCE_OPEN, this.onsoa)
+        logger.warn('mediaSource did not create')
+        this.resolveThenMediaSourceOpen = this.resolveThenMediaSourceOpen
+          ? this.resolveThenMediaSourceOpen
+          : resolve
+        this.rejectThenMediaSourceOpen = this.rejectThenMediaSourceOpen
+            ? this.rejectThenMediaSourceOpen
+            : reject
+        return
+      }
+
+      // deferring execution
+      if (this.mediaSource && this.mediaSource.readyState !== 'open') {
+        logger.warn('readyState is not "open"')
+        this.shouldPlay = true
+        this.resolveThenMediaSourceOpen = this.resolveThenMediaSourceOpen
+          ? this.resolveThenMediaSourceOpen
+          : resolve
+        this.rejectThenMediaSourceOpen = this.rejectThenMediaSourceOpen
+          ? this.rejectThenMediaSourceOpen
+          : reject
+        return
+      }
+
+    }
+
+    onMediaSourceOpen(resolve) {
+      resolve()
+      let mediaSource = this.mediaSource
+      if (mediaSource) {
+        // once received, don't listen anymore to sourceopen event
+        mediaSource.removeEventListener(EVENTS.MEDIA_SOURCE_SOURCE_OPEN, this.onmso)
+      }
+
+      // play was called but stoped and was pend(1.readyState is not open)
+      // and time is come to execute it
+      if (this.shouldPlay) {
+        logger.info(
+          `readyState now is ${this.mediaSource.readyState}, and will be played`,
+          this.playTime,
+          this.audioTack,
+          this.videoTrack
+        )
+        this.shouldPlay = false
+        this._play(this.playTime, this.audioTack, this.videoTrack)
+      }
+    }
+
+    removeMediaSource() {
+      const ms = this.mediaSource
+      if (ms) {
+        if (ms.readyState === 'open') {
+          try {
+            // endOfStream could trigger exception if any sourcebuffer is in updating state
+            // we don't really care about checking sourcebuffer state here,
+            // as we are anyway detaching the MediaSource
+            // let's just avoid this exception to propagate
+            ms.endOfStream()
+          } catch (err) {
+            logger.warn(`onMediaDetaching:${err.message} while calling endOfStream`)
+          }
+        }
+
+        ms.removeEventListener(EVENTS.MEDIA_SOURCE_SOURCE_OPEN, this.onmso)
+        ms.removeEventListener(EVENTS.MEDIA_SOURCE_SOURCE_ENDED, this.onmse)
+        ms.removeEventListener(EVENTS.MEDIA_SOURCE_SOURCE_CLOSE, this.onmsc)
+        this.onmso = null
+        this.onmse = null
+        this.onmsc = null
+      }
+
+      // Detach properly the MediaSource from the HTMLMediaElement as
+      // suggested in https://github.com/w3c/media-source/issues/53.
+      URL.revokeObjectURL(this.media.src)
+      this.media.removeAttribute('src')
+      this.media.load()
+    }
+
+}

--- a/src/controllers/ws.js
+++ b/src/controllers/ws.js
@@ -17,7 +17,7 @@ export default class WS1 {
 
     this.websocket = new WebSocket(wsURL)
     this.websocket.binaryType = 'arraybuffer'
-      // do that for remove event method
+    // do that for remove event method
     this.websocket.addEventListener(EVENTS.WS_OPEN, this.onwso)
     this.websocket.addEventListener(EVENTS.WS_MESSAGE, this.opts.message)
   }
@@ -45,9 +45,10 @@ export default class WS1 {
       : WS_COMMAND_SEEK
     logger.log(`${commandStr}${utc}`)
     this.websocket.send(`${commandStr}${utc}`)
+    debugger
   }
 
-  setTracks() {
+  setTracks(videoTrack, audioTrack) {
     this.websocket.send(`set_tracks=${videoTrack}${audioTrack}`)
   }
 

--- a/src/controllers/ws.js
+++ b/src/controllers/ws.js
@@ -1,0 +1,95 @@
+import EVENTS from '../enums/events'
+
+const WS_COMMAND_SEEK_LIVE = ''
+const WS_COMMAND_SEEK = 'play_from='
+const LIVE = 'live'
+
+import {logger} from '../utils/logger'
+
+export default class WS1 {
+  constructor(opts) {
+    this.opts = opts
+    this.onwso = this.open.bind(this)
+  }
+
+  start(url, time, videoTrack = '', audioTack = '') {
+    const wsURL = getWSURL(url, time, videoTrack, audioTack)
+
+    this.websocket = new WebSocket(wsURL)
+    this.websocket.binaryType = 'arraybuffer'
+      // do that for remove event method
+    this.websocket.addEventListener(EVENTS.WS_OPEN, this.onwso)
+    this.websocket.addEventListener(EVENTS.WS_MESSAGE, this.opts.message)
+  }
+
+  open() {
+    this.resume()
+    this.websocket.removeEventListener(EVENTS.WS_OPEN, this.onwso)
+  }
+
+  send(cmd) {
+    this.websocket.send(cmd)
+  }
+
+  resume() {
+    this.websocket.send('resume')
+  }
+
+  pause() {
+    this.websocket.send('pause')
+  }
+
+  seek(utc) {
+    const commandStr = utc === LIVE
+      ? WS_COMMAND_SEEK_LIVE
+      : WS_COMMAND_SEEK
+    logger.log(`${commandStr}${utc}`)
+    this.websocket.send(`${commandStr}${utc}`)
+  }
+
+  setTracks() {
+    this.websocket.send(`set_tracks=${videoTrack}${audioTrack}`)
+  }
+
+  destroy() {
+    if (this.websocket) {
+      this.websocket.removeEventListener(EVENTS.WS_MESSAGE, this.onwsdm)
+      this.websocket.onclose = function() {} // disable onclose handler first
+      this.websocket.close()
+      this.onwsdm = null
+    }
+  }
+}
+
+// TODO
+export function getWSURL(url, utc, videoTrack, audioTrack) {
+  // TODO: then use @param time it prevent to wrong data from ws(trackID view[47] for example is 100)
+  const time = utc
+
+  if (!time && !videoTrack && !audioTrack) {
+    return url
+  }
+
+  const parsedUrl = parseUrl({url})
+  let othersParams = ''
+
+  if (parsedUrl.query) {
+    const currentParamsKeysValues = parsedUrl.query.split('&').map(keyValue => keyValue.split('='))
+
+    othersParams = currentParamsKeysValues
+      .filter(p => p[0] !== 'from' && p[0] !== 'tracks')
+      .map(kv => kv.join('='))
+      .join('&')
+
+    logger.log(othersParams)
+  }
+
+  const cleanUrl = `${parsedUrl.protocol}//${parsedUrl.host}${parsedUrl.pathname}?`
+  const tracksExists = !!videoTrack || !!audioTrack
+
+  const resultUrl =
+    `${cleanUrl}${tracksExists ? `tracks=${videoTrack}${audioTrack}` : ''}` +
+    `${tracksExists && !!time ? '&' : ''}${!!time ? `from=${Math.floor(time)}` : ''}` +
+    `${(tracksExists || !!time) && !!othersParams ? '&' : ''}${othersParams}`
+  return resultUrl
+}

--- a/src/enums/segments.js
+++ b/src/enums/segments.js
@@ -1,2 +1,3 @@
+export const EVENT_SEGMENT = 'event'
 export const MSE_INIT_SEGMENT = 'mse_init_segment'
 export const MSE_MEDIA_SEGMENT = 'mse_media_segment'

--- a/src/modules/MsePlayer.external.js
+++ b/src/modules/MsePlayer.external.js
@@ -1,6 +1,6 @@
 import WebSocketController from '../controllers/ws'
 import BuffersController from '../controllers/buffers'
-import MediaSourceController from '../controllers/mediaSource'
+// import MediaSourceController from '../controllers/mediaSource'
 
 import {MSE_INIT_SEGMENT, EVENT_SEGMENT} from '../enums/segments'
 
@@ -42,7 +42,6 @@ export default class MSEPlayer {
    * @param opts
    */
   constructor(media, urlStream, opts = {}) {
-    console.log('%constructor Tag', 'background: red;')
     this.opts = opts || {}
     if (this.opts.debug) {
       enableLogs(true)
@@ -68,9 +67,6 @@ export default class MSEPlayer {
     this.onMediaInfo = opts && opts.onMediaInfo
     this.onError = opts && opts.onError
 
-    // this.doArrayBuffer = mseUtils.doArrayBuffer.bind(this)
-    // this.maybeAppend = this.maybeAppend.bind(this)
-
     this.init()
 
     if (media instanceof HTMLMediaElement) {
@@ -85,7 +81,7 @@ export default class MSEPlayer {
      * SourceBuffers Controller
      */
 
-    this.sb = new BuffersController()
+    this.sb = new BuffersController({media})
 
   }
 
@@ -164,6 +160,7 @@ export default class MSEPlayer {
   }
 
   setTracks(tracks) {
+    debugger
     if (!this.mediaInfo) {
       logger.warn('Media info did not loaded. Should try after onMediaInfo triggered or inside.')
       return
@@ -187,10 +184,12 @@ export default class MSEPlayer {
       })
       .join('')
 
+    this.onStartStalling()
     this.ws.setTracks(videoTracksStr, audioTracksStr)
 
     this.videoTrack = videoTracksStr
     this.audioTrack = audioTracksStr
+    // ?
     this._setTracksFlag = true
     this.waitForInitFrame = true
   }

--- a/src/modules/MsePlayer.external.js
+++ b/src/modules/MsePlayer.external.js
@@ -110,6 +110,7 @@ export default class MSEPlayer {
 
       this.ws.seek(utc)
       this.sb.seek()
+      this.onStartStalling()
       // need for determine old frames
       this.seekValue = utc
 

--- a/src/utils/mseUtils.js
+++ b/src/utils/mseUtils.js
@@ -95,6 +95,7 @@ export const checkVideoProgress = (media, player, maxDelay = MAX_DELAY) => evt =
     player.onEndStalling()
     // если поставелна пауза
     if (media.paused && !player._pause && player.playing) {
+      media.currentTime = endTime - 0.0001
       media.play()
     }
   }

--- a/src/utils/mseUtils.js
+++ b/src/utils/mseUtils.js
@@ -61,7 +61,9 @@ export function doArrayBuffer() {
   const segment = this.segments.shift()
 
   if (!segment.isInit) {
+    // last loaded frame's utc
     this.utc = getRealUtcFromData(segment.data)
+    this.lastLoadedUTC = this.utc
   }
 
   this.maybeAppend(segment)
@@ -100,7 +102,7 @@ export const checkVideoProgress = (media, player, maxDelay = MAX_DELAY) => evt =
   if (delay <= maxDelay) {
     return
   }
-
+  debugger
   logger.log('nudge', ct, '->', l ? endTime : '-', ct - endTime)//evt, )
   media.currentTime = endTime - 0.2// (Math.abs(ct - endTime)) //
 }

--- a/src/utils/mseUtils.js
+++ b/src/utils/mseUtils.js
@@ -91,18 +91,18 @@ export const checkVideoProgress = (media, player, maxDelay = MAX_DELAY) => evt =
 
   const endTime = buffered.end(l - 1)
   const delay = Math.abs(endTime - ct)
-
-  if (media.paused && !player._pause && player.playing) {
-    media.play()
-    if (player.onEndStalling) {
-      player.onEndStalling()
+  if (player._stalling) {
+    player.onEndStalling()
+    // если поставелна пауза
+    if (media.paused && !player._pause && player.playing) {
+      media.play()
     }
   }
 
   if (delay <= maxDelay) {
     return
   }
-  debugger
+
   logger.log('nudge', ct, '->', l ? endTime : '-', ct - endTime)//evt, )
   media.currentTime = endTime - 0.2// (Math.abs(ct - endTime)) //
 }


### PR DESCRIPTION
- after seek, pause, setTracks do not playing old frames
- all commands (play, pause, seek, setTracks) invoke onStartStalling and after receive new frames invoke onEndStalling. If useful for displaying loader spinner
- incapsulate websocket, sourceBuffers logic 