### PR TITLE
Fix building. Fix naming mistakes.

### DIFF
--- a/dist/FlussonicMsePlayer.js
+++ b/dist/FlussonicMsePlayer.js
@@ -674,7 +674,7 @@ var MSEPlayer = function () {
       window.humanTime = mseUtils.humanTime;
     }
 
-    _logger.logger.info('[mse-player]:', FlussonicMsePlayer.version);
+    _logger.logger.info('[mse-player]:', MSEPlayer.version);
 
     this.opts = opts || {};
 

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "clean-webpack-plugin": "^0.1.17",
     "directory-named-webpack-plugin": "^2.2.3",
     "jest": "^23.5.0",
+    "eslint": "~4.9.0",
+    "gulp": "~4.0.0",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   },
   "dependencies": {
-    "eslint": "~4.9.0",
-    "gulp": "~4.0.0",
     "parseurl": "~1.3.2"
   },
   "directories": {

--- a/src/modules/MsePlayer.external.js
+++ b/src/modules/MsePlayer.external.js
@@ -48,7 +48,7 @@ export default class MSEPlayer {
       window.humanTime = mseUtils.humanTime
     }
 
-    logger.info('[mse-player]:', FlussonicMsePlayer.version)
+    logger.info('[mse-player]:', MSEPlayer.version)
 
     this.opts = opts || {}
 


### PR DESCRIPTION
1. For correct usage as npm package eslint and gulp must be dev deps.
2. Fix player base class naming mistake.