### PR TITLE
fixing incorrect TrackId in ActiveStreams

### DIFF
--- a/src/controllers/buffers.js
+++ b/src/controllers/buffers.js
@@ -151,8 +151,9 @@ export default class BuffersController {
     if (data[type].length === 1) {
       this.audioTrackId = null
     }
-    data[type].forEach((s, index) => {
-      this[s.content === VIDEO ? 'videoTrackId' : 'audioTrackId'] = {index, id: s.id}
+    data[type].forEach(s => {
+      const {content, id} = s
+      this[content === VIDEO ? 'videoTrackId' : 'audioTrackId'] = {index: id - 1, id}
     })
   }
 


### PR DESCRIPTION
In method onMediaInfo(raw MetaData) after init (first load wss source) ActiveStreams param include incorrect TrackId:
![image](https://user-images.githubusercontent.com/39203346/98017652-5f815e80-1e21-11eb-9a56-2ed37809e53b.png)
and after switching track TrackId not updating:
![image](https://user-images.githubusercontent.com/39203346/98018140-0108b000-1e22-11eb-9bf7-f24dc2d90115.png)


